### PR TITLE
flake: fix `inputs.filestash-src` auto-update

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: update-flake-inputs
         run: |
           set -xeuo pipefail
-          nix flake lock --update-input filestash-nix --commit-lock-file
+          nix flake lock --update-input filestash-src --commit-lock-file --commit-lockfile-summary 'flake.lock: update `inputs.filestash-src`'
       - name: update-package-lock
         run: |
           set -xeuo pipefail


### PR DESCRIPTION
https://github.com/MatthewCroughan/filestash-nix/commit/02687f2796f55fcf81c7a404720bf9dba3a29bb3 had a little typo (`filestash-nix` vs `filestash-src`).

I also added the flag
```
--commit-lockfile-summary 'flake.lock: update `inputs.filestash-src`'
```
to differentiate them a bit from the manual `flake.lock: Update` ones.
Lowercase "update" to be on par with `filestash: update dream-lock.json`.

`--commit-lockfile-summary` has been added in nix v2.6. The pipeline runs v2.12, so it should just work fine.

A commit would look like this:
 ```patch
 From 286e98c695168c895b27321cb0ba1bcfb456a28e Mon Sep 17 00:00:00 2001
From: IndeedNotJames <git@indeednotjames.com>
Date: Sun, 26 Mar 2023 14:39:49 +0200
Subject: [PATCH] flake.lock: update `inputs.filestash-src`
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit

Flake lock file updates:

• Updated input 'filestash-src':
    'github:mickael-kerjean/filestash/6eb26e9a7035df018973f7484d5e8b55966b7031' (2022-11-20)
  → 'github:mickael-kerjean/filestash/26ee2006f4b0b5af5335e92238fd4a24c1a832c0' (2023-03-25)
---
 flake.lock | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)

diff --git a/flake.lock b/flake.lock
index 7a5deec..d448eec 100644
--- a/flake.lock
+++ b/flake.lock
@@ -114,11 +114,11 @@
     "filestash-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1668978605,
-        "narHash": "sha256-tY+veItOVINOCABYtX+YwcnNbvcr6T/DyybiBwLoU0M=",
+        "lastModified": 1679755428,
+        "narHash": "sha256-omx0AShSmo0dTiYP/WghWERQhTuFW/eVKR6iL42WsNI=",
         "owner": "mickael-kerjean",
         "repo": "filestash",
-        "rev": "6eb26e9a7035df018973f7484d5e8b55966b7031",
+        "rev": "26ee2006f4b0b5af5335e92238fd4a24c1a832c0",
         "type": "github"
       },
       "original": {
-- 
2.39.2


```