### PR TITLE
filestash: overhaul and fix package build

### DIFF
--- a/dream2nix-packages/filestash/dream-lock.json
+++ b/dream2nix-packages/filestash/dream-lock.json
@@ -24,6 +24,28 @@
         [ "babel-core", "6.26.3" ]
       ]
     },
+    "d": {
+      "1.0.1": [
+        [ "es5-ext", "0.10.62" ]
+      ]
+    },
+    "es5-ext": {
+      "0.10.62": [
+        [ "es6-symbol", "3.1.3" ]
+      ]
+    },
+    "es6-iterator": {
+      "2.0.3": [
+        [ "d", "1.0.1" ],
+        [ "es5-ext", "0.10.62" ],
+        [ "es6-symbol", "3.1.3" ]
+      ]
+    },
+    "es6-symbol": {
+      "3.1.3": [
+        [ "d", "1.0.1" ]
+      ]
+    },
     "function.prototype.name": {
       "1.1.5": [
         [ "es-abstract", "1.21.2" ]
@@ -103,6 +125,11 @@
       "1.2.8": [
         [ "@nodelib/fs.scandir", "2.1.5" ],
         [ "fastq", "1.15.0" ]
+      ]
+    },
+    "@types/localforage": {
+      "0.0.34": [
+        [ "localforage", "1.10.0" ]
       ]
     },
     "@types/react": {
@@ -1325,6 +1352,12 @@
         [ "array-find-index", "1.0.2" ]
       ]
     },
+    "d": {
+      "1.0.1": [
+        [ "es5-ext", "0.10.62" ],
+        [ "type", "1.2.0" ]
+      ]
+    },
     "dashdash": {
       "1.14.1": [
         [ "assert-plus", "1.0.0" ]
@@ -1462,6 +1495,19 @@
         [ "tapable", "0.2.9" ]
       ]
     },
+    "epubjs": {
+      "0.3.93": [
+        [ "@types/localforage", "0.0.34" ],
+        [ "@xmldom/xmldom", "0.7.9" ],
+        [ "core-js", "3.29.1" ],
+        [ "event-emitter", "0.3.5" ],
+        [ "jszip", "3.10.1" ],
+        [ "localforage", "1.10.0" ],
+        [ "lodash", "4.17.21" ],
+        [ "marks-pane", "1.0.9" ],
+        [ "path-webpack", "0.0.3" ]
+      ]
+    },
     "errno": {
       "0.1.8": [
         [ "prr", "1.0.1" ]
@@ -1527,6 +1573,26 @@
         [ "is-callable", "1.2.7" ],
         [ "is-date-object", "1.0.5" ],
         [ "is-symbol", "1.0.4" ]
+      ]
+    },
+    "es5-ext": {
+      "0.10.62": [
+        [ "es6-iterator", "2.0.3" ],
+        [ "es6-symbol", "3.1.3" ],
+        [ "next-tick", "1.1.0" ]
+      ]
+    },
+    "es6-iterator": {
+      "2.0.3": [
+        [ "d", "1.0.1" ],
+        [ "es5-ext", "0.10.62" ],
+        [ "es6-symbol", "3.1.3" ]
+      ]
+    },
+    "es6-symbol": {
+      "3.1.3": [
+        [ "d", "1.0.1" ],
+        [ "ext", "1.7.0" ]
       ]
     },
     "es6-templates": {
@@ -1625,6 +1691,12 @@
         [ "estraverse", "5.3.0" ]
       ]
     },
+    "event-emitter": {
+      "0.3.5": [
+        [ "d", "1.0.1" ],
+        [ "es5-ext", "0.10.62" ]
+      ]
+    },
     "evp_bytestokey": {
       "1.0.3": [
         [ "md5.js", "1.3.5" ],
@@ -1675,6 +1747,11 @@
         [ "type-is", "1.6.18" ],
         [ "utils-merge", "1.0.1" ],
         [ "vary", "1.1.2" ]
+      ]
+    },
+    "ext": {
+      "1.7.0": [
+        [ "type", "2.7.2" ]
       ]
     },
     "extend-shallow": {
@@ -1730,13 +1807,14 @@
         [ "@nodelib/fs.stat", "2.0.5" ],
         [ "@nodelib/fs.walk", "1.2.8" ],
         [ "@types/json-schema", "7.0.11" ],
+        [ "@types/localforage", "0.0.34" ],
         [ "@types/prop-types", "15.7.5" ],
         [ "@types/react", "18.0.29" ],
         [ "@types/scheduler", "0.16.3" ],
         [ "@videojs/http-streaming", "2.16.2" ],
         [ "@videojs/vhs-utils", "3.0.5" ],
         [ "@videojs/xhr", "2.6.0" ],
-        [ "@xmldom/xmldom", "0.8.6" ],
+        [ "@xmldom/xmldom", "0.7.9" ],
         [ "abbrev", "1.1.1" ],
         [ "accepts", "1.3.8" ],
         [ "acorn", "8.8.2" ],
@@ -1966,6 +2044,7 @@
         [ "csstype", "3.1.1" ],
         [ "currently-unhandled", "0.4.1" ],
         [ "cyclist", "1.0.1" ],
+        [ "d", "1.0.1" ],
         [ "dashdash", "1.14.1" ],
         [ "debug", "2.6.9" ],
         [ "decamelize", "1.2.0" ],
@@ -2006,6 +2085,7 @@
         [ "end-of-stream", "1.4.4" ],
         [ "enhanced-resolve", "3.4.1" ],
         [ "entities", "2.2.0" ],
+        [ "epubjs", "0.3.93" ],
         [ "errno", "0.1.8" ],
         [ "error-ex", "1.3.2" ],
         [ "es-abstract", "1.21.2" ],
@@ -2013,7 +2093,10 @@
         [ "es-set-tostringtag", "2.0.1" ],
         [ "es-shim-unscopables", "1.0.0" ],
         [ "es-to-primitive", "1.2.1" ],
+        [ "es5-ext", "0.10.62" ],
         [ "es5-shim", "4.6.7" ],
+        [ "es6-iterator", "2.0.3" ],
+        [ "es6-symbol", "3.1.3" ],
         [ "es6-templates", "0.2.3" ],
         [ "escape-html", "1.0.3" ],
         [ "escape-string-regexp", "1.0.5" ],
@@ -2029,11 +2112,13 @@
         [ "estraverse", "5.3.0" ],
         [ "esutils", "2.0.3" ],
         [ "etag", "1.8.1" ],
+        [ "event-emitter", "0.3.5" ],
         [ "events", "3.3.0" ],
         [ "evp_bytestokey", "1.0.3" ],
         [ "exif-js", "2.3.0" ],
         [ "expand-brackets", "2.1.4" ],
         [ "express", "4.18.2" ],
+        [ "ext", "1.7.0" ],
         [ "extend", "3.0.2" ],
         [ "extend-shallow", "3.0.2" ],
         [ "extglob", "2.0.4" ],
@@ -2126,6 +2211,7 @@
         [ "ieee754", "1.2.1" ],
         [ "iferr", "0.1.5" ],
         [ "ignore", "5.2.4" ],
+        [ "immediate", "3.0.6" ],
         [ "import-fresh", "3.3.0" ],
         [ "imurmurhash", "0.1.4" ],
         [ "in-publish", "2.0.1" ],
@@ -2194,15 +2280,18 @@
         [ "jsonify", "0.0.1" ],
         [ "jsprim", "1.4.2" ],
         [ "jsx-ast-utils", "3.3.3" ],
+        [ "jszip", "3.10.1" ],
         [ "keycode", "2.2.1" ],
         [ "kind-of", "6.0.3" ],
         [ "lazy-cache", "1.0.4" ],
         [ "lcid", "1.0.0" ],
         [ "levn", "0.4.1" ],
+        [ "lie", "3.3.0" ],
         [ "little-loader", "0.2.0" ],
         [ "load-json-file", "1.1.0" ],
         [ "loader-runner", "2.4.0" ],
         [ "loader-utils", "0.2.17" ],
+        [ "localforage", "1.10.0" ],
         [ "locate-path", "6.0.0" ],
         [ "lodash", "4.17.21" ],
         [ "lodash-es", "4.17.21" ],
@@ -2223,6 +2312,7 @@
         [ "map-cache", "0.2.2" ],
         [ "map-obj", "1.0.1" ],
         [ "map-visit", "1.0.0" ],
+        [ "marks-pane", "1.0.9" ],
         [ "math-expression-evaluator", "1.4.0" ],
         [ "md5.js", "1.3.5" ],
         [ "media-typer", "0.3.0" ],
@@ -2255,6 +2345,7 @@
         [ "natural-compare", "1.4.0" ],
         [ "negotiator", "0.6.3" ],
         [ "neo-async", "2.6.2" ],
+        [ "next-tick", "1.1.0" ],
         [ "no-case", "2.3.2" ],
         [ "node-gyp", "3.8.0" ],
         [ "node-libs-browser", "2.2.1" ],
@@ -2310,6 +2401,7 @@
         [ "path-parse", "1.0.7" ],
         [ "path-to-regexp", "1.8.0" ],
         [ "path-type", "3.0.0" ],
+        [ "path-webpack", "0.0.3" ],
         [ "pbkdf2", "3.1.2" ],
         [ "pdfjs-dist", "2.6.347" ],
         [ "performance-now", "2.1.0" ],
@@ -2524,6 +2616,7 @@
         [ "tty-browserify", "0.0.0" ],
         [ "tunnel-agent", "0.6.0" ],
         [ "tweetnacl", "0.14.5" ],
+        [ "type", "1.2.0" ],
         [ "type-check", "0.4.0" ],
         [ "type-fest", "0.20.2" ],
         [ "type-is", "1.6.18" ],
@@ -3186,6 +3279,14 @@
         [ "object.assign", "4.1.4" ]
       ]
     },
+    "jszip": {
+      "3.10.1": [
+        [ "lie", "3.3.0" ],
+        [ "pako", "1.0.11" ],
+        [ "readable-stream", "2.3.8" ],
+        [ "setimmediate", "1.0.5" ]
+      ]
+    },
     "kind-of": {
       "3.2.2": [
         [ "is-buffer", "1.1.6" ]
@@ -3203,6 +3304,14 @@
       "0.4.1": [
         [ "prelude-ls", "1.2.1" ],
         [ "type-check", "0.4.0" ]
+      ]
+    },
+    "lie": {
+      "3.1.1": [
+        [ "immediate", "3.0.6" ]
+      ],
+      "3.3.0": [
+        [ "immediate", "3.0.6" ]
       ]
     },
     "load-json-file": {
@@ -3230,6 +3339,11 @@
         [ "big.js", "5.2.2" ],
         [ "emojis-list", "3.0.0" ],
         [ "json5", "2.2.3" ]
+      ]
+    },
+    "localforage": {
+      "1.10.0": [
+        [ "lie", "3.1.1" ]
       ]
     },
     "locate-path": {
@@ -5148,6 +5262,13 @@
         "url": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz"
       }
     },
+    "@types/localforage": {
+      "0.0.34": {
+        "hash": "sha512-tJxahnjm9dEI1X+hQSC5f2BSd/coZaqbIl1m3TCl0q9SVuC52XcXfV0XmoCU1+PmjyucuVITwoTnN8OlTbEXXA==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/@types/localforage/-/localforage-0.0.34.tgz"
+      }
+    },
     "@types/prop-types": {
       "15.7.5": {
         "hash": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
@@ -5191,6 +5312,11 @@
       }
     },
     "@xmldom/xmldom": {
+      "0.7.9": {
+        "hash": "sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.9.tgz"
+      },
       "0.8.6": {
         "hash": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==",
         "type": "http",
@@ -6834,6 +6960,11 @@
         "hash": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
         "type": "http",
         "url": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz"
+      },
+      "3.29.1": {
+        "hash": "sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/core-js/-/core-js-3.29.1.tgz"
       }
     },
     "core-util-is": {
@@ -6963,6 +7094,13 @@
         "hash": "sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==",
         "type": "http",
         "url": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz"
+      }
+    },
+    "d": {
+      "1.0.1": {
+        "hash": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/d/-/d-1.0.1.tgz"
       }
     },
     "dashdash": {
@@ -7270,6 +7408,13 @@
         "url": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz"
       }
     },
+    "epubjs": {
+      "0.3.93": {
+        "hash": "sha512-c06pNSdBxcXv3dZSbXAVLE1/pmleRhOT6mXNZo6INKmvuKpYB65MwU/lO7830czCtjIiK9i+KR+3S+p0wtljrw==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/epubjs/-/epubjs-0.3.93.tgz"
+      }
+    },
     "errno": {
       "0.1.8": {
         "hash": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
@@ -7319,11 +7464,32 @@
         "url": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz"
       }
     },
+    "es5-ext": {
+      "0.10.62": {
+        "hash": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz"
+      }
+    },
     "es5-shim": {
       "4.6.7": {
         "hash": "sha512-jg21/dmlrNQI7JyyA2w7n+yifSxBng0ZralnSfVZjoCawgNTCnS+yBCyVM9DL5itm7SUnDGgv7hcq2XCZX4iRQ==",
         "type": "http",
         "url": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.7.tgz"
+      }
+    },
+    "es6-iterator": {
+      "2.0.3": {
+        "hash": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz"
+      }
+    },
+    "es6-symbol": {
+      "3.1.3": {
+        "hash": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz"
       }
     },
     "es6-templates": {
@@ -7456,6 +7622,13 @@
         "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
       }
     },
+    "event-emitter": {
+      "0.3.5": {
+        "hash": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
+      }
+    },
     "events": {
       "3.3.0": {
         "hash": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
@@ -7489,6 +7662,13 @@
         "hash": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
         "type": "http",
         "url": "https://registry.npmjs.org/express/-/express-4.18.2.tgz"
+      }
+    },
+    "ext": {
+      "1.7.0": {
+        "hash": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz"
       }
     },
     "extend": {
@@ -8240,6 +8420,13 @@
         "url": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz"
       }
     },
+    "immediate": {
+      "3.0.6": {
+        "hash": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz"
+      }
+    },
     "import-fresh": {
       "3.3.0": {
         "hash": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
@@ -8801,6 +8988,13 @@
         "url": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz"
       }
     },
+    "jszip": {
+      "3.10.1": {
+        "hash": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz"
+      }
+    },
     "keycode": {
       "2.2.1": {
         "hash": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg==",
@@ -8851,6 +9045,18 @@
         "url": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz"
       }
     },
+    "lie": {
+      "3.1.1": {
+        "hash": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz"
+      },
+      "3.3.0": {
+        "hash": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz"
+      }
+    },
     "little-loader": {
       "0.2.0": {
         "hash": "sha512-MYNYfBqP/f5C7XO6MR2cylmAzAKgBkDD1UGZ4KjxFviV3mKbjOEnxVj1nhnN3i2zcwbkPeUDsjAMjLnlL9kRLA==",
@@ -8887,6 +9093,13 @@
         "hash": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
         "type": "http",
         "url": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz"
+      }
+    },
+    "localforage": {
+      "1.10.0": {
+        "hash": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz"
       }
     },
     "locate-path": {
@@ -9042,6 +9255,13 @@
         "hash": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
         "type": "http",
         "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz"
+      }
+    },
+    "marks-pane": {
+      "1.0.9": {
+        "hash": "sha512-Ahs4oeG90tbdPWwAJkAAoHg2lRR8lAs9mZXETNPO9hYg3AkjUJBKi1NQ4aaIQZVGrig7c/3NUV1jANl8rFTeMg==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/marks-pane/-/marks-pane-1.0.9.tgz"
       }
     },
     "math-expression-evaluator": {
@@ -9286,6 +9506,13 @@
         "hash": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
         "type": "http",
         "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
+      }
+    },
+    "next-tick": {
+      "1.1.0": {
+        "hash": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz"
       }
     },
     "no-case": {
@@ -9721,6 +9948,13 @@
         "hash": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
         "type": "http",
         "url": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz"
+      }
+    },
+    "path-webpack": {
+      "0.0.3": {
+        "hash": "sha512-AmeDxedoo5svf7aB3FYqSAKqMxys014lVKBzy1o/5vv9CtU7U4wgGWL1dA2o6MOzcD53ScN4Jmiq6VbtLz1vIQ==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/path-webpack/-/path-webpack-0.0.3.tgz"
       }
     },
     "pbkdf2": {
@@ -11384,6 +11618,18 @@
         "hash": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
         "type": "http",
         "url": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+      }
+    },
+    "type": {
+      "1.2.0": {
+        "hash": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/type/-/type-1.2.0.tgz"
+      },
+      "2.7.2": {
+        "hash": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
+        "type": "http",
+        "url": "https://registry.npmjs.org/type/-/type-2.7.2.tgz"
       }
     },
     "type-check": {

--- a/flake.lock
+++ b/flake.lock
@@ -114,11 +114,11 @@
     "filestash-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1668978605,
-        "narHash": "sha256-tY+veItOVINOCABYtX+YwcnNbvcr6T/DyybiBwLoU0M=",
+        "lastModified": 1679755428,
+        "narHash": "sha256-omx0AShSmo0dTiYP/WghWERQhTuFW/eVKR6iL42WsNI=",
         "owner": "mickael-kerjean",
         "repo": "filestash",
-        "rev": "6eb26e9a7035df018973f7484d5e8b55966b7031",
+        "rev": "26ee2006f4b0b5af5335e92238fd4a24c1a832c0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -310,11 +310,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1674407282,
-        "narHash": "sha256-2qwc8mrPINSFdWffPK+ji6nQ9aGnnZyHSItVcYDZDlk=",
+        "lastModified": 1679748960,
+        "narHash": "sha256-BP8XcYHyj1NxQi04RpyNW8e7KiXSoI+Fy1tXIK2GfdA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ab1254087f4cdf4af74b552d7fc95175d9bdbb49",
+        "rev": "da26ae9f6ce2c9ab380c0f394488892616fc5a6a",
         "type": "github"
       },
       "original": {

--- a/nix/filestash-module.nix
+++ b/nix/filestash-module.nix
@@ -22,7 +22,6 @@ in {
       tmpfiles.rules = [
         "d  ${cfg.dataDir}/data        0771 - - - -"
         "d  ${cfg.dataDir}/data/state  0771 - - - -"
-        "L+ ${cfg.dataDir}/data/public 0771 - - - ${cfg.package}/data/public"
       ];
       services.filestash = {
         description = "A modern web client for SFTP and more";

--- a/pkgs/filestash/default.nix
+++ b/pkgs/filestash/default.nix
@@ -1,4 +1,4 @@
-{ buildGo120Module
+{ buildGoModule
 , dream2nix
 , filestash-src
 , glib
@@ -71,7 +71,7 @@ let
     '';
   };
 in
-buildGo120Module {
+buildGoModule {
   pname = "filestash";
   version = "unstable-" + filestash-src.shortRev;
 

--- a/pkgs/filestash/default.nix
+++ b/pkgs/filestash/default.nix
@@ -1,4 +1,18 @@
-{ dream2nix, stdenv, self, python, runCommand, pkgs, filestash-src, glib, vips, libraw, pkg-config, buildGoModule }:
+{ buildGo120Module
+, dream2nix
+, filestash-src
+, glib
+, gotools
+, libraw
+, pkg-config
+, pkgs
+, python
+, self
+, stdenv
+, vips
+, util-linux
+, writeShellScriptBin
+}:
 let
   updateScript = (dream2nix.lib.makeFlakeOutputs {
     inherit pkgs;
@@ -7,7 +21,7 @@ let
     settings = [ { subsystemInfo.nodejs = "14"; subsystemInfo.npmArgs = "--legacy-peer-deps"; } ];
     autoProjects = true;
   }).packages.${pkgs.hostPlatform.system}.filestash.resolve;
-  js = ((dream2nix.lib.init { inherit pkgs; }).dream2nix-interface.makeOutputsForDreamLock {
+  frontend = ((dream2nix.lib.init { inherit pkgs; }).dream2nix-interface.makeOutputsForDreamLock {
     dreamLock = ../../dream2nix-packages/filestash/dream-lock.json;
     sourceOverrides = oldSources: {
       "filestash"."0.0.0" = filestash-src;
@@ -22,33 +36,6 @@ let
       };
     };
   }).packages.filestash;
-  go = buildGoModule {
-    name = "filestash-golang";
-    src = filestash-src;
-    vendorSha256 = null;
-    buildInputs = [
-      glib libresize libtranscode vips libraw
-    ];
-    nativeBuildInputs = [
-      pkg-config
-    ];
-    patchPhase = ''
-      substituteInPlace server/plugin/plg_backend_ftp_only/index.go \
-        --replace '"crypto/tls"' '//"crypto/tls"'
-    '';
-    preBuild = let
-      libresizePath = (builtins.replaceStrings [ "/" ] [ "\\/" ] libresize.outPath);
-      libtranscodePath = (builtins.replaceStrings [ "/" ] [ "\\/" ] libtranscode.outPath);
-    in ''
-      make build_init
-      sed -ie 's/-L.\/deps -l:libresize_linux_amd64.a/-L${libresizePath}\/lib -l:libresize.a -lvips/' server/plugin/plg_image_light/lib_resize_linux_amd64.go
-      sed -ie 's/-L.\/deps -l:libtranscode_linux_amd64.a/-L${libtranscodePath}\/lib -l:libtranscode.a -lraw/' server/plugin/plg_image_light/lib_transcode_linux_amd64.go
-    '';
-    postInstall = ''
-      cp $out/bin/server $out/bin/filestash
-    '';
-    excludedPackages = "\\(server/generator\\|server/plugin/plg_starter_http2\\|server/plugin/plg_starter_https\\|server/plugin/plg_search_sqlitefts\\)";
-  };
   libtranscode = stdenv.mkDerivation {
     name = "libtranscode";
     src = filestash-src + "/server/plugin/plg_image_light/deps/src";
@@ -84,14 +71,69 @@ let
     '';
   };
 in
-pkgs.stdenv.mkDerivation {
-  passthru.update = updateScript;
-  name = "filestash";
-  phases = [ "InstallPhase" ];
-  InstallPhase = ''
-    mkdir -p $out/bin
-    cp ${go}/bin/filestash $out/bin
-    mkdir -p $out/data
-    cp -r ${js}/lib/node_modules/filestash/dist/data/public $out/data
+buildGo120Module {
+  pname = "filestash";
+  version = "unstable-" + filestash-src.shortRev;
+
+  src = frontend + "/lib/node_modules/filestash";
+
+  vendorHash = null;
+
+  excludedPackages = [
+    "server/generator"
+    "server/plugin/plg_starter_http2"
+    "server/plugin/plg_starter_https"
+    "server/plugin/plg_search_sqlitefts"
+  ];
+
+  buildInputs = [
+    glib
+    libraw
+    libresize
+    libtranscode
+    vips
+  ];
+
+  nativeBuildInputs = [
+    (writeShellScriptBin "git" "echo '${filestash-src.rev}'")
+    gotools
+    util-linux
+    pkg-config
+  ];
+
+  patches = [
+    ## Use flake input's lastModified as build date (see `postPatch` phase), as
+    ## `time.Now()` is impure. The build date is used in Filestash's own version
+    ## reporting and the http User-Agent when connecting to a backend.
+    ./fix-impure-build-date.patch
+  ];
+
+  postPatch =
+    let
+      platform = {
+        aarch64-linux = "linux_arm";
+        x86_64-linux = "linux_amd64";
+      }.${pkgs.hostPlatform.system} or (throw "Unsupported system: ${pkgs.hostPlatform.system}");
+    in
+    ''
+      substituteInPlace server/generator/constants.go --subst-var-by build_date '${toString filestash-src.lastModified}'
+
+      ## fix "imported and not used" errors
+      goimports -w server/
+
+      sed -i 's#-L./deps -l:libresize_${platform}.a#-L${libresize.outPath}/lib -l:libresize.a -lvips#' server/plugin/plg_image_light/lib_resize_${platform}.go
+      sed -i 's#-L./deps -l:libtranscode_${platform}.a#-L${libtranscode.outPath}/lib -l:libtranscode.a -lraw#' server/plugin/plg_image_light/lib_transcode_${platform}.go
+
+      ## server/** requires globstar
+      shopt -s globstar
+      rename --no-overwrite --verbose linux_arm.go linux_arm64.go server/**
+    '';
+
+  preBuild = ''
+    make build_init
+  '';
+
+  postInstall = ''
+    mv $out/bin/server $out/bin/filestash
   '';
 }

--- a/pkgs/filestash/fix-impure-build-date.patch
+++ b/pkgs/filestash/fix-impure-build-date.patch
@@ -1,0 +1,13 @@
+diff --git a/server/generator/constants.go b/server/generator/constants.go
+index 401f12e6..49dcf659 100644
+--- a/server/generator/constants.go
++++ b/server/generator/constants.go
+@@ -19,7 +19,7 @@ func init() {
+     BUILD_REF = "%s"
+     BUILD_DATE = "%s"
+ }
+-`, strings.TrimSpace(b.String()), time.Now().Format("20060102"))
++`, strings.TrimSpace(b.String()), time.Unix(@build_date@, 0).Format("20060102"))
+
+ 	f, err := os.OpenFile("../common/constants_generated.go", os.O_CREATE|os.O_WRONLY, os.ModePerm)
+ 	if err != nil {


### PR DESCRIPTION
Tested the binary on x86_64-linux and aarch64-linux manually.
Everything seems to work, including image and thumbnails.
VM test builds as well.

Mostly copy-pasted from the commit messages:
- Filestash refers to go 1.20 in its `go.mod`, so we bump nixpkgs once, so we can use `buildGo120Module`
- Upstream uses go:embed now, so we need to use the frontend build as src
- `lib.getVersion` reports something useful now
- `git rev-parse HEAD` mock, which is called in `server/generator/constants.go`
- `excludedPackages` can be a list of strings
- Fix build date impurity
- Fix build for aarch64
- Remove `data/public` from the nixos module as the assets are now embedded